### PR TITLE
MAINT: scripted fix for precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
         exclude: '^(conda-recipe/meta.yaml)$'
     -   id: debug-statements
 
--   repo: https://gitlab.com/pycqa/flake8
+-   repo: https://github.com/pycqa/flake8
     rev: 3.7.9
     hooks:
     -   id: flake8


### PR DESCRIPTION
PR generated from script to fix .pre-commit-config.yaml in all repos, switching out the missing flake8 gitlab mirror for github.